### PR TITLE
changes to groups and groupmembers apis

### DIFF
--- a/backend/src/routes/groups/addGroup.ts
+++ b/backend/src/routes/groups/addGroup.ts
@@ -7,15 +7,23 @@ export async function addGroup(req, res, next) {
     try {
         const groupDetails = groupUserSchema.parse(req.body);
 
-        const groupDBRecord = await prisma.groups.create({
-           data: {
-            group_name: groupDetails.groupName,
-            group_type: groupDetails.groupType,
-            created_by: groupDetails.userId
-           }
-        })
+        const groupDBRecord = await prisma.$transaction(async () => {
+            const group = await prisma.groups.create({
+                data: {
+                    group_name: groupDetails.groupName,
+                    group_type: groupDetails.groupType,
+                    created_by: groupDetails.userId
+                }
+            });
+            await prisma.groupMembers.create({
+                data: {
+                    group_id: group.group_id,
+                    member_id: group.created_by
+                }
+            })
 
-        console.log(groupDBRecord);
+            return group;
+        })
 
         res.send({
             "groupId": groupDBRecord.group_id.toString(),

--- a/backend/src/routes/groups/users/addUsersToGroup.ts
+++ b/backend/src/routes/groups/users/addUsersToGroup.ts
@@ -6,7 +6,6 @@ export async function addUsersToGroup(req, res, next) {
     try {
         //query should be like check if user is part of the group first
         //then make one query per user id in the users 
-        console.log(req)
         const userId = req.body.userId;
         const groupId = Number(req.params.group_id)
         const userIds = req.body.users;
@@ -23,20 +22,21 @@ export async function addUsersToGroup(req, res, next) {
         }
         let groupMemberList: groupMemberType[] = [];
 
-        for(const userId in userIds) {
+        userIds.forEach(userId => {
             groupMemberList.push({
                 group_id: groupId,
                 member_id: Number(userId)
             })
-        }
-
+        });
+        
         const count = await prisma.groupMembers.createMany({
             data: groupMemberList,
         })
 
         res.send({
-            count: count
-        })
+            status: "Success",
+            groupMembers: count
+        });
     } catch(e) {
         next()
     }


### PR DESCRIPTION
**groups api:**
1. While adding a group, we are going to add the group creator directly to the group members table. If one of the transaction fails, i.e creating the group, or adding the user to the group members, prisma rollsback the transaction, and sends the failure status.

**groupMembers api:**
1. The added for loop before was wrong, since we are trying to add the array index to the groupMembers array, i.e say groupMembers: [2,3,4], we were adding indexes to groupMemberList >> {group_id: 2, member_id: 0}, {group_id: 2, member_id: 1}, and {group_id: 2, member_id: 2}, which is wrong, so made changes to that code, to add the user_ids properly to the list.
2. Removed console logs
3. Modified the response to send status and the count of the rows added (which is basically the number of members that were in the payload)

**Note:** In case one of the members is failed to add to the groupMemberList, due to member already being present in the group (unique (group_id, user_id) condition failure), or the user not in the users table, the whole transaction is rolled. back automatically by prisma.


**Yet to add:**
1. Need to check the error conditions and see if proper response is being returned.

**Known Issues:**
1. If while adding the group, the type_id is not present in the db, say {"groupName": "test","groupType": 10}, (say only valid group type ids are from 1 - 5, then we are not returning proper error message. Current error message

```
{
    "errorCode": "ERROR_CREATING_GROUP",
    "message": "error creating group",
    "details": "none"
}
```
2. proper error case handling for groupMember api 
 